### PR TITLE
Fix a couple of fatal errors

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -81,7 +81,7 @@ class Module
 	public function errorProcess(MvcEvent $e)
 	{
 		/** @var \Zend\Di\Di $di */
-		$di = $e->getTarget()->getServiceLocator()->get('di');
+		$di = $e->getApplication()->getServiceManager()->get('di');
 
 		$eventParams = $e->getParams();
 

--- a/Module.php
+++ b/Module.php
@@ -88,24 +88,26 @@ class Module
 		/** @var array $configuration */
 		$configuration = $e->getApplication()->getConfiguration();
 
-		/** @var \Exception $exception */
-		$exception = $eventParams['exception'];
-
 		$vars = array();
-		if ($configuration['errors']['show_exceptions']['message']) {
-			$vars['error-message'] = $exception->getMessage();
+		if (isset($eventParams['exception'])) {
+			/** @var \Exception $exception */
+			$exception = $eventParams['exception'];
+	
+			if ($configuration['errors']['show_exceptions']['message']) {
+				$vars['error-message'] = $exception->getMessage();
+			}
+			if ($configuration['errors']['show_exceptions']['trace']) {
+				$vars['error-trace'] = $exception->getTrace();
+			}
 		}
-		if ($configuration['errors']['show_exceptions']['trace']) {
-			$vars['error-trace'] = $exception->getTrace();
-		}
-
+		
 		if (empty($vars)) {
 			$vars['error'] = 'Something went wrong';
 		}
 
 		/** @var PostProcessor\AbstractPostProcessor $postProcessor */
 		$postProcessor = $di->get($configuration['errors']['post_processor'], array(
-			'vars'     => array('exception: ' => $exception->getMessage()),
+			'vars'     => $vars,
 			'response' => $e->getResponse()
 		));
 


### PR DESCRIPTION
If a route/controller is not found getTarget() returns the Application instead. getServiceLocator() subsequently fails as it is undefined in Application. getApplication()->getServiceManager()->get('di') works in both cases.

Also, a fatal error occurs if no exception exists.
